### PR TITLE
package: describe the relationship to style-dictionary

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "homepage": "https://github.com/jakobw/style-dictionary-format-json-schema#readme",
   "devDependencies": {
     "jest": "^26.6.1"
+  },
+  "peerDependencies": {
+    "style-dictionary": "2.x"
   }
 }


### PR DESCRIPTION
style-dictionary is a peer dependency, a vehicle used to "express the
compatibility of your package with a host tool or library"[0].

Expressing the relationship make sense both conceptually (there is no
point in people using style-dictionary-format-json-schema without using
style-dictionary) and also from a practical point of view (as
style-dictionary-format-json-schema uses the style-dictionary API which
might change).

I could not find (did not try hard, though) info about the registerFormat()
API of style-dictionary version 1 and if it was compatible but I doubt
there are many users of it any more.

[0]: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#peerdependencies